### PR TITLE
OpenShift Pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
 source "https://rubygems.org"
 
+gem "rake"
+
 group :jekyll_plugins do
   gem "jekyll-paginate"
   gem "jekyll-sitemap"
   gem "octopress-autoprefixer"
+end
+
+group :test do
+  gem "html-proofer"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (6.3.6.2)
       execjs
     colorator (0.1)
+    colorize (0.8.1)
+    concurrent-ruby (1.0.5)
+    ethon (0.10.1)
+      ffi (>= 1.3.0)
     execjs (2.6.0)
     ffi (1.9.10)
+    html-proofer (3.7.4)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.7)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
+    i18n (0.9.0)
+      concurrent-ruby (~> 1.0)
     jekyll (3.1.6)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
@@ -27,23 +49,38 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
+    mini_portile2 (2.3.0)
+    minitest (5.10.3)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     octopress-autoprefixer (2.0.0)
       autoprefixer-rails
       jekyll (~> 3.0)
+    parallel (1.12.0)
+    public_suffix (3.0.0)
+    rake (12.2.1)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.21)
+    thread_safe (0.3.6)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll-paginate
   jekyll-sitemap
   octopress-autoprefixer
+  rake
 
 BUNDLED WITH
-   1.10.6
+   1.15.4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+node('jenkins-slave-ruby-centos7') {
+    stage('Build') {
+        git url: "https://github.com/ComputerScienceHouse/blog.git"
+        sh "bundle install"
+        sh "bundle exec rake build:production"
+    }
+
+    stage('Test') {
+        sh "bundle exec rake test"
+    }
+
+    stage('Build Image') {
+        sh "oc start-build blog --from-dir=_site"
+    }
+}

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,54 @@
+require 'html-proofer'
+
+$outputDir = "./_site"
+$testOpts = {
+  # An array of Strings containing domains that will be treated as internal urls
+  :internal_domains => ["blog.csh.rit.edu"],
+  # Ignore errors "linking to internal hash # that does not exist"
+  :url_ignore => ["#"],
+  # Allow empty alt tags (e.g. alt="") as these represent presentational images
+  :empty_alt_ignore => true,
+  # Automatically add extension (e.g. .html) to file paths, to allow extensionless URLs
+  :assume_extension => true
+}
+
+task :default => ["serve:development"]
+
+desc "cleans the output directory"
+task :clean do
+  sh "jekyll clean"
+end
+
+namespace :build do
+
+  desc "build development site"
+  task :development => [:clean] do
+    sh "jekyll build --drafts"
+  end
+
+  desc "build production site"
+  task :production => [:clean] do
+    sh "JEKYLL_ENV=production jekyll build --config=_config.yml"
+  end
+end
+
+namespace :serve do
+
+  desc "serve development site"
+  task :development => [:clean] do
+    sh "jekyll serve --drafts"
+  end
+
+  desc "serve production site"
+  task :production => [:clean] do
+    sh "JEKYLL_ENV=production jekyll serve --config=_config.yml"
+  end
+end
+
+namespace :test do
+
+  desc "test production build"
+  task :production => ["build:production"] do
+    HTMLProofer.check_directory($outputDir, $testOpts).run
+  end
+end

--- a/_config.yml
+++ b/_config.yml
@@ -3,19 +3,19 @@ email: pr@csh.rit.edu
 baseurl:
 paginate: 5
 paginate_path: "/blog/page-:num"
-google_analytics: 
+google_analytics:
 
 # SEO settings
 title: Computer Science House Blog
 description: Computer Science House at RIT's Blog
-url: blog.csh.rit.edu
-twitter_username: 
-default_img: 
+url: https://blog.csh.rit.edu
+twitter_username:
+default_img:
 
 # Profile settings
 name: Computer Science House
-profile_img: 
-profile: 
+profile_img:
+profile:
 social:
   github: https://github.com/ComputerScienceHouse
 

--- a/_config.yml
+++ b/_config.yml
@@ -29,4 +29,15 @@ sass:
   style: compressed
 
 # Gems
-gems: [jekyll-paginate, jekyll-sitemap, octopress-autoprefixer]
+gems:
+- jekyll-paginate
+- jekyll-sitemap
+- octopress-autoprefixer
+
+# Build Exclusions
+exclude:
+- vendor
+- Gemfile
+- Gemfile.lock
+- README.md
+- LICENSE.txt


### PR DESCRIPTION
Adds support for OpenShift [pipeline builds](https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html#pipeline-build), which gives us a bit more flexibility in the build process and produces cleaner results than an S2I image.

Also added a quick test that will check to make sure the generated HTML is valid and all external URLs resolve at build time.