### PR TITLE
travis: create travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+    - 2.3.3
+
+script: bundle exec rake test 
+
+env:
+    global:
+        - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+sudo: false

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,12 @@ $testOpts = {
   # Automatically add extension (e.g. .html) to file paths, to allow extensionless URLs
   :assume_extension => true,
   # LinkedIn blocks connections from html-proofer, ignore 999 error
-  :http_status_ignore => [999]
+  :http_status_ignore => [999],
+  # SSL seems to be broken on TravisCI, so we'll ignore SSL errors.
+  :typhoeus => {
+    :ssl_verifypeer => 0,
+    :ssl_verifyhost => 0,
+  }
 }
 
 task :default => ["serve:development"]


### PR DESCRIPTION
This will enable building and testing the blog on each PR and will make sure that bad PRs don't break the site.

Fixes #32.