### PR TITLE
bundle: add therubyracer to jekyll_plugins deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :jekyll_plugins do
   gem "jekyll-paginate"
   gem "jekyll-sitemap"
   gem "octopress-autoprefixer"
+  gem "therubyracer"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     jekyll-watch (1.3.0)
       listen (~> 3.0)
     kramdown (1.9.0)
+    libv8 (3.16.14.19)
     liquid (3.0.6)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
@@ -62,9 +63,13 @@ GEM
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    ref (2.0.0)
     rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.21)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thread_safe (0.3.6)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
@@ -81,6 +86,7 @@ DEPENDENCIES
   jekyll-sitemap
   octopress-autoprefixer
   rake
+  therubyracer
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
octopress-autoprefixer requires a Javascript runtime, so add one to the
jekyll_plugins group for systems which don't have any JS runtime
installed system-wide.